### PR TITLE
Correct link to technical reference document

### DIFF
--- a/2021-06-17-account.state.part1.html
+++ b/2021-06-17-account.state.part1.html
@@ -66,7 +66,7 @@ It will be verified later.
 
 # Verifying state tree
 
-There’s a pretty detailed description of merkle trees in [chapter 4 in catapult-whitepaper](https://docs.symbolplatform.com/symbol-technicalref/main.pdf), so I’m not gonna repeat that here.
+There’s a pretty detailed description of merkle trees in [chapter 4 in catapult-whitepaper](https://symbol.github.io/symbol-technicalref/main.pdf), so I’m not gonna repeat that here.
 
 Let’s query current merkle tree path of that account. The REST API endpoint for this is `/accounts/<account-id>/merkle`, returned data looks like following:
 


### PR DESCRIPTION
Update domain to symbol.github.io